### PR TITLE
Add Support for Integer, Boolean, and Number Types in Schema Conversion

### DIFF
--- a/packages/manifest-to-bicep-extension/src/converter.ts
+++ b/packages/manifest-to-bicep-extension/src/converter.ts
@@ -128,6 +128,12 @@ export function addSchemaType(
     return factory.addStringType()
   } else if (schema.type === 'object') {
     return factory.addObjectType(name, addObjectProperties(schema, factory))
+  } else if (schema.type === 'number') {
+    return factory.addNumberType()
+  } else if (schema.type === 'integer') {
+    return factory.addIntegerType()
+  } else if (schema.type === 'boolean') {
+    return factory.addBooleanType()
   } else {
     throw new Error(`Unsupported schema type: ${schema.type}`)
   }

--- a/packages/manifest-to-bicep-extension/src/manifest.ts
+++ b/packages/manifest-to-bicep-extension/src/manifest.ts
@@ -16,7 +16,7 @@ export interface APIVersion {
 }
 
 export interface Schema {
-  type: 'string' | 'object'
+  type: 'string' | 'object' | 'integer' | 'number' | 'boolean'
   description?: string
   properties?: Record<string, Schema>
   required?: string[]

--- a/packages/manifest-to-bicep-extension/test/converter.test.ts
+++ b/packages/manifest-to-bicep-extension/test/converter.test.ts
@@ -144,6 +144,39 @@ describe('addSchemaType', () => {
     expect(added.properties).toHaveProperty('a')
     expect(added.properties).toHaveProperty('b')
   })
+
+  it('should add a number type', () => {
+    const schema: Schema = {
+      type: 'number',
+    }
+
+    const result = addSchemaType(schema, 'test', factory)
+    const added = factory.types[result.index]
+    expect(added).toBeDefined()
+    expect(added.type).toBe(TypeBaseKind.NumberType)
+  })
+
+  it('should add an integer type', () => {
+    const schema: Schema = {
+      type: 'integer',
+    }
+
+    const result = addSchemaType(schema, 'test', factory)
+    const added = factory.types[result.index]
+    expect(added).toBeDefined()
+    expect(added.type).toBe(TypeBaseKind.IntegerType)
+  })
+
+  it('should add a boolean type', () => {
+    const schema: Schema = {
+      type: 'boolean',
+    }
+
+    const result = addSchemaType(schema, 'test', factory)
+    const added = factory.types[result.index]
+    expect(added).toBeDefined()
+    expect(added.type).toBe(TypeBaseKind.BooleanType)
+  })
 })
 
 describe('addObjectProperties', () => {

--- a/packages/manifest-to-bicep-extension/test/manifest.test.ts
+++ b/packages/manifest-to-bicep-extension/test/manifest.test.ts
@@ -18,4 +18,14 @@ describe('parseManifest', () => {
       },
     })
   })
+
+  it('should parse a manifest with different data types in schema', () => {
+    const input = fs.readFileSync(__dirname + '/testdata/valid-with-schema-properties.yaml', 'utf8')
+    const result: ResourceProvider = parseManifest(input)
+
+    expect(result.types['testResources'].apiVersions['2025-01-01-preview'].schema.properties).toHaveProperty('a', expect.objectContaining({ type: 'number' }))
+    expect(result.types['testResources'].apiVersions['2025-01-01-preview'].schema.properties).toHaveProperty('b', expect.objectContaining({ type: 'integer' }))
+    expect(result.types['testResources'].apiVersions['2025-01-01-preview'].schema.properties).toHaveProperty('c', expect.objectContaining({ type: 'boolean' }))
+    expect(result.types['testResources'].apiVersions['2025-01-01-preview'].schema.properties).toHaveProperty('c', expect.objectContaining({ type: 'string' }))
+  })
 })

--- a/packages/manifest-to-bicep-extension/test/testdata/valid-with-schema-properties.yaml
+++ b/packages/manifest-to-bicep-extension/test/testdata/valid-with-schema-properties.yaml
@@ -1,0 +1,21 @@
+name: MyCompany.Resources
+types:
+  testResources:
+    apiVersions:
+      '2025-01-01-preview':
+        schema:
+          type: object
+          properties:
+            a:
+              type: number
+              description: "A numeric property"
+            b:
+              type: integer
+              description: "An integer property"
+            c:
+              type: boolean
+              description: "A boolean property"
+            d:
+              type: string
+              description: "A string property"
+        capabilities: ['Recipes']


### PR DESCRIPTION
Currently only string and object types are supported for schema. Added support for integer, number, and boolean types.