### PR TITLE
Revert "Update RP field name to namespace"

### DIFF
--- a/packages/manifest-to-bicep-extension/src/converter.ts
+++ b/packages/manifest-to-bicep-extension/src/converter.ts
@@ -43,7 +43,7 @@ export function convert(manifest: ResourceProvider): {
   })
 
   const indexContent = buildIndex(typeFiles, (log) => console.log(log), {
-    name: 'radius' + manifest.namespace.toLowerCase().replace('.', ''),
+    name: 'radius' + manifest.name.toLowerCase().replace('.', ''),
     version: '0.0.1',
     isSingleton: false,
   })
@@ -63,7 +63,7 @@ export function addResourceTypeForApiVersion(
   apiVersion: APIVersion,
   factory: TypeFactory
 ): TypeReference {
-  const qualifiedName = `${manifest.namespace}/${resourceTypeName}@${apiVersionName}`
+  const qualifiedName = `${manifest.name}/${resourceTypeName}@${apiVersionName}`
 
   const propertyType = factory.addObjectType(
     `${resourceTypeName}Properties`,
@@ -97,7 +97,7 @@ export function addResourceTypeForApiVersion(
     },
     type: {
       type: factory.addStringLiteralType(
-        `${manifest.namespace}/${resourceTypeName}`
+        `${manifest.name}/${resourceTypeName}`
       ),
       flags:
         ObjectTypePropertyFlags.ReadOnly |

--- a/packages/manifest-to-bicep-extension/src/manifest.ts
+++ b/packages/manifest-to-bicep-extension/src/manifest.ts
@@ -1,7 +1,7 @@
 import { parse } from 'yaml'
 
 export interface ResourceProvider {
-  namespace: string
+  name: string
   types: Record<string, ResourceType>
 }
 

--- a/packages/manifest-to-bicep-extension/test/converter.test.ts
+++ b/packages/manifest-to-bicep-extension/test/converter.test.ts
@@ -25,7 +25,7 @@ describe('addResourceTypeForApiVersion', () => {
 
   it('should add a resource type', () => {
     const manifest: ResourceProvider = {
-      namespace: 'Applications.Test',
+      name: 'Applications.Test',
       types: {
         testResources: {
           apiVersions: {

--- a/packages/manifest-to-bicep-extension/test/manifest.test.ts
+++ b/packages/manifest-to-bicep-extension/test/manifest.test.ts
@@ -6,7 +6,7 @@ describe('parseManifest', () => {
   it('should parse a manifest file with required fields', () => {
     const input = fs.readFileSync(__dirname + '/testdata/valid.yaml', 'utf8')
     const result: ResourceProvider = parseManifest(input)
-    expect(result.namespace).toBe('MyCompany.Resources')
+    expect(result.name).toBe('MyCompany.Resources')
     expect(result.types).toStrictEqual({
       testResources: {
         apiVersions: {

--- a/packages/manifest-to-bicep-extension/test/testdata/valid-with-schema-properties.yaml
+++ b/packages/manifest-to-bicep-extension/test/testdata/valid-with-schema-properties.yaml
@@ -1,4 +1,4 @@
-namespace: MyCompany.Resources
+name: MyCompany.Resources
 types:
   testResources:
     apiVersions:

--- a/packages/manifest-to-bicep-extension/test/testdata/valid.yaml
+++ b/packages/manifest-to-bicep-extension/test/testdata/valid.yaml
@@ -1,4 +1,4 @@
-namespace: MyCompany.Resources
+name: MyCompany.Resources
 types:
   testResources:
     apiVersions:


### PR DESCRIPTION
Reverts radius-project/bicep-tools#15

As 0.47.0 is pointing to previous npm package, rad publish extension command fails on 0.47.0